### PR TITLE
The "staticBaseUri" config parameter no longer need to duplicate for env

### DIFF
--- a/core/config/config.example.php
+++ b/core/config/config.example.php
@@ -43,12 +43,7 @@ return new \Phalcon\Config(
             /**
              * Change URL cdn if you want it
              */
-            'development'    => [
-                'staticBaseUri' => '/',
-            ],
-            'production'  => [
-                'staticBaseUri' => '/',
-            ],
+            'staticBaseUri'       => '/',
             /**
              * For developers: Phanbook debugging mode.
              *


### PR DESCRIPTION
See the Url Resolver definition