### PR TITLE
Use phalcongelist/dd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   - export PHP_MAJOR="$(echo $TRAVIS_PHP_VERSION | cut -d '.' -f 1,2)"
   - phpenv config-rm xdebug.ini || true
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
-  - travis_retry composer install --prefer-dist --no-interaction
+  - travis_retry composer install --prefer-dist --no-interaction --ignore-platform-reqs
   - ( bash tests/_ci/install_zephir.sh )
   - bash tests/_ci/install_prereqs_$PHP_MAJOR.sh
 

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "fzaninotto/faker": "^1.6",
         "squizlabs/php_codesniffer": "^2.7",
         "codeception/codeception": "2.2.x-dev",
-        "phalcon/zephir": "dev-master"
+        "phalcon/zephir": "dev-master",
+        "phalcongelist/dd": "^1"
     },
     "support": {
         "issues": "https://github.com/phanbook/phanbook/issues",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "131898df6287becb90b1d0fb614c83b0",
-    "content-hash": "3d3eac88ef1bfda8222683484b1c134e",
+    "hash": "a5f126d319b17e842fecbf790c91fd4f",
+    "content-hash": "c0bd18ec551fc5bc4f5a2dca0bb37607",
     "packages": [
         {
             "name": "elasticsearch/elasticsearch",
@@ -1353,6 +1353,55 @@
                 "extension"
             ],
             "time": "2016-10-23 12:01:25"
+        },
+        {
+            "name": "phalcongelist/dd",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phalcongelist/dd.git",
+                "reference": "16e0572c62e8924294d0e0ca677d5cfb34e34d75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phalcongelist/dd/zipball/16e0572c62e8924294d0e0ca677d5cfb34e34d75",
+                "reference": "16e0572c62e8924294d0e0ca677d5cfb34e34d75",
+                "shasum": ""
+            },
+            "require": {
+                "ext-phalcon": ">=3.0",
+                "php": ">= 5.4  <8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/helper.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Serghei Iakovlev",
+                    "email": "serghei@phalconphp.com",
+                    "role": "developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/phalcongelist/dd/graphs/contributors"
+                }
+            ],
+            "description": "This package will add the `dd` helper to your Phalcon application.",
+            "homepage": "https://github.com/phalcongelist/dd",
+            "keywords": [
+                "dd",
+                "dump",
+                "phalcon",
+                "utils"
+            ],
+            "time": "2016-11-06 21:09:57"
         },
         {
             "name": "phpdocumentor/reflection-common",


### PR DESCRIPTION
```php
$user = Users::query()
    ->where('email = :string:')
    ->bind(['string' => $email])
    ->limit(1)
    ->execute();

dd($user, null);
```

![dd2](https://cloud.githubusercontent.com/assets/1256298/20041746/74fe6b14-a476-11e6-856d-6079c0058c72.png)


@duythien I suggest to remove all other dump-related helper functions from `bootstrap/helpers.php` eg. `vd`, `vdd`, `pr`, etc. They are redundant