### PR TITLE
Correcting spelling of SMTP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ BEANSTALK_PORT=11300
 ELASTIC_INDEX=phanbook
 ELASTIC_TYPE=posts
 
-MAIL_DRIVER=smpt
+MAIL_DRIVER=smtp
 MAIL_FROM_NAME=Phanbook
 MAIL_FROM_ADDRESS=no-reply@phanbook.dev
 MAIL_HOST=mailtrap.io

--- a/tests/.env.travis
+++ b/tests/.env.travis
@@ -39,7 +39,7 @@ BEANSTALK_PORT=11300
 ELASTIC_INDEX=phanbook
 ELASTIC_TYPE=posts
 
-MAIL_DRIVER=smpt
+MAIL_DRIVER=smtp
 MAIL_FROM_NAME=Phanbook
 MAIL_FROM_ADDRESS=no-reply@phanbook.dev
 MAIL_HOST=mailtrap.io


### PR DESCRIPTION
It seems the spelling of 'smtp' is incorrect, and I'm assuming that the reference in these config files needs to be corrected.