### PR TITLE
Correcting spelling of SMTP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,7 @@ BEANSTALK_PORT=11300
 ELASTIC_INDEX=phanbook
 ELASTIC_TYPE=posts
 
-MAIL_DRIVER=smpt
+MAIL_DRIVER=smtp
 MAIL_FROM_NAME=Phanbook
 MAIL_FROM_ADDRESS=no-reply@phanbook.dev
 MAIL_HOST=mailtrap.io

--- a/tests/.env.travis
+++ b/tests/.env.travis
@@ -41,7 +41,7 @@ BEANSTALK_PORT=11300
 ELASTIC_INDEX=phanbook
 ELASTIC_TYPE=posts
 
-MAIL_DRIVER=smpt
+MAIL_DRIVER=smtp
 MAIL_FROM_NAME=Phanbook
 MAIL_FROM_ADDRESS=no-reply@phanbook.dev
 MAIL_HOST=mailtrap.io


### PR DESCRIPTION
I assume it is a simple spelling error, correcting spelling of 'smtp' in two config files.