### PR TITLE
Fix auth when use remember

### DIFF
--- a/core/common/library/Auth/Auth.php
+++ b/core/common/library/Auth/Auth.php
@@ -180,7 +180,7 @@ class Auth extends Component
 
         if (strcmp($cToken, $uToken) === 0) {
             $remember = RememberTokens::findFirst([
-                'condition' => 'usersId = ?0 AND token = ?1',
+                'usersId = ?0 AND token = ?1',
                 'bind' => [$user->getId(), $uToken],
                 'order' => 'createdAt DESC' // it mean only remember token
             ]);


### PR DESCRIPTION
When we are login with login remmber, after that exit a browser go to home page it will get a error like this

```
( ! ) Fatal error: Uncaught PDOException: SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens in /usr/share/nginx/html/phanbook/core/common/library/Auth/Auth.php on line 185
```
So that i try to check log db, here result

```
[Wed, 01 Feb 17 00:31:23 +0000][DEBUG] SELECT `rememberTokens`.`id`, `rememberTokens`.`usersId`, `rememberTokens`.`token`, `rememberTokens`.`userAgent`, `rememberTokens`.`createdAt` FROM `rememberTokens` ORDER BY `rememberTokens`.`createdAt` DESC LIMIT :APL0 [1, 8f7aaf0d6df2a94995c8cb2a15dd4d54, 1]
```

Then try test special case 

```
$remember = RememberTokens::findFirst([
            'condition' => 'usersId = ?0 AND token = ?1',
            'bind' => [1, '8f7aaf0d6df2a94995c8cb2a15dd4d54'],
            'order' => 'createdAt DESC' // it mean only remember token
        ]);
``` 

It will be get the error sample above