### PR TITLE
Make tags user friendly when no tags exist

### DIFF
--- a/content/themes/default/tag.volt
+++ b/content/themes/default/tag.volt
@@ -20,6 +20,8 @@
                         </li>
                     </ul>
                 </div><!-- /Slide1 -->
+                {% else %}
+                No tags exist. Please create some in the dashboard.
                 {% endfor %}
             </div>
            <!-- /.control-box -->


### PR DESCRIPTION
When no tags exist, you see a confusing page with no content, making you question whether the code is broken or if there is something wrong with your config. The user really should be seeing a message explaining what's going on.


Before:  
---

![tags-before](https://user-images.githubusercontent.com/1922199/29432822-de5f5108-8351-11e7-850f-baaf9e6f5b55.png)

After:  
---

![tags-after](https://user-images.githubusercontent.com/1922199/29432865-ff53b8fe-8351-11e7-86a8-bcf9b3a6c52b.png)